### PR TITLE
add --gpio-chip and --gpio-mockup flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,20 @@ development box does not have `/dev/gpiochip0`, you can load the `gpio-mockup`
 kernel module to create a mockup:
 
 ```bash
-make load-gpio-mockup
+sudo make load-gpio-mockup
+```
+
+To unload the gpio-mockup kernel module again, run:
+
+```bash
+sudo make unload-gpio-mockup
+```
+
+A more convenient way to automatically load the `gpio-mockup` kernel module and
+unload it again is to simply pass the `--gpio-mockup` flag to rfoutlet:
+
+```bash
+sudo rfoutlet --gpio-mockup [...]
 ```
 
 Run `make` without arguments to see available commands for building and testing.

--- a/cmd/chip.go
+++ b/cmd/chip.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"github.com/warthog618/gpiod"
+	"github.com/warthog618/gpiod/mockup"
+)
+
+type device struct {
+	*gpiod.Chip
+	*mockup.Mockup
+}
+
+func (d *device) Close() error {
+	err := d.Chip.Close()
+	if err != nil {
+		return err
+	}
+
+	if d.Mockup != nil {
+		log.Debug("removing gpio mockup")
+		return d.Mockup.Close()
+	}
+
+	return nil
+}
+
+func openGPIODevice(cmd *cobra.Command) (*device, error) {
+	gpioChipName, _ := cmd.Flags().GetString("gpio-chip")
+	gpioMockup, _ := cmd.Flags().GetBool("gpio-mockup")
+
+	var (
+		dev *device = &device{}
+		err error
+	)
+
+	if gpioMockup {
+		log.Debug("creating gpio mockup")
+		dev.Mockup, err = mockup.New([]int{40}, false)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create gpio mockup: %v", err)
+		}
+	}
+
+	dev.Chip, err = gpiod.NewChip(gpioChipName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open gpio device: %v", err)
+	}
+
+	return dev, nil
+}

--- a/cmd/sniff.go
+++ b/cmd/sniff.go
@@ -8,7 +8,6 @@ import (
 	"github.com/martinohmann/rfoutlet/pkg/gpio"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/warthog618/gpiod"
 )
 
 func NewSniffCommand() *cobra.Command {
@@ -21,7 +20,7 @@ func NewSniffCommand() *cobra.Command {
 		Short: "Sniff codes sent out to remote controlled outlets",
 		Long:  "The sniff command can be used to sniff codes sent out to remote controlled outlets.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return options.Run()
+			return options.Run(cmd)
 		},
 	}
 
@@ -38,14 +37,14 @@ func (o *SniffOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().UintVar(&o.Pin, "pin", o.Pin, "gpio pin to sniff on")
 }
 
-func (o *SniffOptions) Run() error {
-	chip, err := gpiod.NewChip(gpioChipName)
+func (o *SniffOptions) Run(cmd *cobra.Command) error {
+	device, err := openGPIODevice(cmd)
 	if err != nil {
-		return fmt.Errorf("failed to open gpio device: %v", err)
+		return err
 	}
-	defer chip.Close()
+	defer device.Close()
 
-	receiver, err := gpio.NewReceiver(chip, int(o.Pin))
+	receiver, err := gpio.NewReceiver(device.Chip, int(o.Pin))
 	if err != nil {
 		return fmt.Errorf("failed to create gpio receiver: %v", err)
 	}

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,7 @@ github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
 github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
@@ -146,6 +147,7 @@ github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9q
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
@@ -158,8 +160,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -182,14 +186,17 @@ github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0Qu
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/pilebones/go-udev v0.0.0-20180820235104-043677e09b13 h1:Y+ynP+0QIjUejN2tsuIlWOJG1CThJy6amRuWlBL94Vg=
 github.com/pilebones/go-udev v0.0.0-20180820235104-043677e09b13/go.mod h1:MXAPLpvZeTqLpU1eO6kFXzU0uBMooSGc1MPXAcBoy1M=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -396,6 +403,7 @@ google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRn
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=

--- a/main.go
+++ b/main.go
@@ -48,6 +48,8 @@ func newRootCommand() *cobra.Command {
 	}
 
 	cmd.PersistentFlags().BoolVar(&debug, "debug", debug, "enable debug mode. this will cause more verbose output")
+	cmd.PersistentFlags().String("gpio-chip", "gpiochip0", "name of the GPIO chip to interact with")
+	cmd.PersistentFlags().Bool("gpio-mockup", false, "automatically load and unload the gpio-mockup kernel module, useful for testing")
 
 	return cmd
 }


### PR DESCRIPTION
Allows using a different gpio chip device.

Furthermore this makes the usage of mock gpio more convenient.

Instead of running

```
sudo make load-gpio-mockup
sudo ./rfoutlet [...]
sudo make unload-gpio-mockup
```

the same can now be achieved via

```
sudo ./rfoutlet --gpio-mockup [...]
```