### PR TITLE
move commands to command package

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -1,5 +1,5 @@
-// Package command provides the interfaces for commands that can be pushed
-// into a command queue for the controller to consume.
+// Package command provides commands that can be pushed into a command queue
+// for the controller to consume.
 package command
 
 import "github.com/martinohmann/rfoutlet/internal/outlet"

--- a/internal/command/commands.go
+++ b/internal/command/commands.go
@@ -1,11 +1,9 @@
-// Package commands contains the commands can be handled by the controller.
-package commands
+package command
 
 import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/martinohmann/rfoutlet/internal/command"
 	"github.com/martinohmann/rfoutlet/internal/outlet"
 	"github.com/martinohmann/rfoutlet/internal/schedule"
 )
@@ -23,13 +21,13 @@ const (
 // StatusCommand is sent by a connected client to retrieve the list of current
 // outlet groups. This usually happens when the client first connects.
 type StatusCommand struct {
-	sender command.Sender
+	sender Sender
 }
 
-// Execute implements command.Command.
+// Execute implements Command.
 //
 // It sends the registered outlet groups back to the sender.
-func (c StatusCommand) Execute(context command.Context) (bool, error) {
+func (c StatusCommand) Execute(context Context) (bool, error) {
 	groups := context.GetGroups()
 
 	msg, err := json.Marshal(groups)
@@ -42,8 +40,8 @@ func (c StatusCommand) Execute(context command.Context) (bool, error) {
 	return false, nil
 }
 
-// SetSender implements command.SenderAwareCommand.
-func (c *StatusCommand) SetSender(sender command.Sender) {
+// SetSender implements SenderAwareCommand.
+func (c *StatusCommand) SetSender(sender Sender) {
 	c.sender = sender
 }
 
@@ -55,10 +53,10 @@ type OutletCommand struct {
 	Action string `json:"action"`
 }
 
-// Execute implements command.Command.
+// Execute implements Command.
 //
 // It switches an outlet based on the transmitted action.
-func (c OutletCommand) Execute(context command.Context) (bool, error) {
+func (c OutletCommand) Execute(context Context) (bool, error) {
 	outlet, ok := context.GetOutlet(c.OutletID)
 	if !ok {
 		return false, fmt.Errorf("outlet %q does not exist", c.OutletID)
@@ -91,10 +89,10 @@ type GroupCommand struct {
 	Action string `json:"action"`
 }
 
-// Execute implements command.Command.
+// Execute implements Command.
 //
 // It switches a group of outlets based on the transmitted action.
-func (c GroupCommand) Execute(context command.Context) (bool, error) {
+func (c GroupCommand) Execute(context Context) (bool, error) {
 	group, ok := context.GetGroup(c.GroupID)
 	if !ok {
 		return false, fmt.Errorf("outlet group %q does not exist", c.GroupID)
@@ -134,11 +132,11 @@ type IntervalCommand struct {
 	Interval schedule.Interval `json:"interval"`
 }
 
-// Execute implements command.Command.
+// Execute implements Command.
 //
 // It add, updates or deletes an interval from the outlet's schedule based on
 // the transmitted action.
-func (c IntervalCommand) Execute(context command.Context) (bool, error) {
+func (c IntervalCommand) Execute(context Context) (bool, error) {
 	outlet, ok := context.GetOutlet(c.OutletID)
 	if !ok {
 		return false, fmt.Errorf("outlet %q does not exist", c.OutletID)
@@ -191,10 +189,10 @@ type StateCorrectionCommand struct {
 	DesiredState outlet.State
 }
 
-// Execute implements command.Command.
+// Execute implements Command.
 //
 // It switch an outlet to the detected state.
-func (c StateCorrectionCommand) Execute(context command.Context) (bool, error) {
+func (c StateCorrectionCommand) Execute(context Context) (bool, error) {
 	// If the outlet was already switched to the desired state after we
 	// submitted the command, we can bail out early.
 	if c.Outlet.GetState() == c.DesiredState {

--- a/internal/command/commands_test.go
+++ b/internal/command/commands_test.go
@@ -1,11 +1,10 @@
-package commands
+package command
 
 import (
 	"bytes"
 	"errors"
 	"testing"
 
-	"github.com/martinohmann/rfoutlet/internal/command"
 	"github.com/martinohmann/rfoutlet/internal/outlet"
 	"github.com/martinohmann/rfoutlet/internal/schedule"
 	"github.com/stretchr/testify/assert"
@@ -21,7 +20,7 @@ func (s *fakeSender) Send(msg []byte) {
 }
 
 func TestStatusCommand(t *testing.T) {
-	ctx, r, _ := command.NewTestContext()
+	ctx, r, _ := NewTestContext()
 
 	s := &fakeSender{}
 
@@ -39,7 +38,7 @@ func TestStatusCommand(t *testing.T) {
 }
 
 func TestOutletCommand(t *testing.T) {
-	ctx, r, _ := command.NewTestContext()
+	ctx, r, _ := NewTestContext()
 
 	o := &outlet.Outlet{ID: "foo"}
 
@@ -55,7 +54,7 @@ func TestOutletCommand(t *testing.T) {
 }
 
 func TestGroupCommand(t *testing.T) {
-	ctx, r, _ := command.NewTestContext()
+	ctx, r, _ := NewTestContext()
 
 	o1 := &outlet.Outlet{ID: "foo", State: outlet.StateOn}
 	o2 := &outlet.Outlet{ID: "baz"}
@@ -85,7 +84,7 @@ func TestGroupCommand(t *testing.T) {
 }
 
 func TestIntervalCommand(t *testing.T) {
-	ctx, r, _ := command.NewTestContext()
+	ctx, r, _ := NewTestContext()
 
 	o := &outlet.Outlet{ID: "foo", Schedule: schedule.New()}
 
@@ -162,7 +161,7 @@ func TestStateCorrectionCommand(t *testing.T) {
 				DesiredState: test.desiredState,
 			}
 
-			ctx, _, s := command.NewTestContext()
+			ctx, _, s := NewTestContext()
 			s.Err = test.switchErr
 
 			broadcast, err := cmd.Execute(ctx)

--- a/internal/statedrift/detector.go
+++ b/internal/statedrift/detector.go
@@ -5,7 +5,6 @@ package statedrift
 
 import (
 	"github.com/martinohmann/rfoutlet/internal/command"
-	"github.com/martinohmann/rfoutlet/internal/controller/commands"
 	"github.com/martinohmann/rfoutlet/internal/outlet"
 	"github.com/martinohmann/rfoutlet/pkg/gpio"
 	"github.com/sirupsen/logrus"
@@ -50,13 +49,13 @@ func (d *Detector) Run(stopCh <-chan struct{}) {
 			for _, o := range d.Registry.GetOutlets() {
 				if result.Code == o.CodeOn && o.GetState() != outlet.StateOn {
 					found = true
-					d.CommandQueue <- commands.StateCorrectionCommand{
+					d.CommandQueue <- command.StateCorrectionCommand{
 						Outlet:       o,
 						DesiredState: outlet.StateOn,
 					}
 				} else if result.Code == o.CodeOff && o.GetState() != outlet.StateOff {
 					found = true
-					d.CommandQueue <- commands.StateCorrectionCommand{
+					d.CommandQueue <- command.StateCorrectionCommand{
 						Outlet:       o,
 						DesiredState: outlet.StateOff,
 					}

--- a/internal/statedrift/detector_test.go
+++ b/internal/statedrift/detector_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/martinohmann/rfoutlet/internal/command"
-	"github.com/martinohmann/rfoutlet/internal/controller/commands"
 	"github.com/martinohmann/rfoutlet/internal/outlet"
 	"github.com/martinohmann/rfoutlet/pkg/gpio"
 	"github.com/stretchr/testify/assert"
@@ -49,8 +48,8 @@ func TestDetector(t *testing.T) {
 	}()
 
 	expected := []command.Command{
-		commands.StateCorrectionCommand{Outlet: o1, DesiredState: outlet.StateOn},
-		commands.StateCorrectionCommand{Outlet: o2, DesiredState: outlet.StateOff},
+		command.StateCorrectionCommand{Outlet: o1, DesiredState: outlet.StateOn},
+		command.StateCorrectionCommand{Outlet: o2, DesiredState: outlet.StateOff},
 	}
 
 	received := make([]command.Command, 0)

--- a/internal/timeswitch/timeswitch.go
+++ b/internal/timeswitch/timeswitch.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/martinohmann/rfoutlet/internal/command"
-	"github.com/martinohmann/rfoutlet/internal/controller/commands"
 	"github.com/martinohmann/rfoutlet/internal/outlet"
 	"github.com/sirupsen/logrus"
 )
@@ -65,7 +64,7 @@ func (s *TimeSwitch) check() {
 		// We only send out commands if the outlet is not in the desired state
 		// to avoid spamming the command queue.
 		if outlet.GetState() != desiredState {
-			s.CommandQueue <- commands.StateCorrectionCommand{
+			s.CommandQueue <- command.StateCorrectionCommand{
 				Outlet:       outlet,
 				DesiredState: desiredState,
 			}

--- a/internal/timeswitch/timeswitch_test.go
+++ b/internal/timeswitch/timeswitch_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/martinohmann/rfoutlet/internal/command"
-	"github.com/martinohmann/rfoutlet/internal/controller/commands"
 	"github.com/martinohmann/rfoutlet/internal/outlet"
 	"github.com/martinohmann/rfoutlet/internal/schedule"
 	"github.com/stretchr/testify/assert"
@@ -62,7 +61,7 @@ func TestTimeSwitch(t *testing.T) {
 				},
 			},
 			expectedCommands: []command.Command{
-				commands.StateCorrectionCommand{
+				command.StateCorrectionCommand{
 					DesiredState: outlet.StateOn,
 					Outlet: &outlet.Outlet{
 						State: outlet.StateOff,
@@ -110,7 +109,7 @@ func TestTimeSwitch(t *testing.T) {
 				},
 			},
 			expectedCommands: []command.Command{
-				commands.StateCorrectionCommand{
+				command.StateCorrectionCommand{
 					DesiredState: outlet.StateOff,
 					Outlet: &outlet.Outlet{
 						State: outlet.StateOn,

--- a/internal/websocket/client_test.go
+++ b/internal/websocket/client_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/martinohmann/rfoutlet/internal/command"
-	"github.com/martinohmann/rfoutlet/internal/controller/commands"
 	"github.com/posener/wstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,14 +28,14 @@ func TestClient_listenRead(t *testing.T) {
 					"id":     "foo",
 				},
 			},
-			expectedCmdType: &commands.OutletCommand{},
+			expectedCmdType: &command.OutletCommand{},
 		},
 		{
 			name: "status action",
 			data: map[string]interface{}{
 				"type": "status",
 			},
-			expectedCmdType: &commands.StatusCommand{},
+			expectedCmdType: &command.StatusCommand{},
 		},
 		{
 			name: "unknown command",

--- a/internal/websocket/command.go
+++ b/internal/websocket/command.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/martinohmann/rfoutlet/internal/command"
-	"github.com/martinohmann/rfoutlet/internal/controller/commands"
 )
 
 // Type is the type of a command.
@@ -32,13 +31,13 @@ type Envelope struct {
 func decodeCommand(envelope Envelope) (command.Command, error) {
 	switch envelope.Type {
 	case OutletType:
-		return decode(envelope.Data, &commands.OutletCommand{})
+		return decode(envelope.Data, &command.OutletCommand{})
 	case GroupType:
-		return decode(envelope.Data, &commands.GroupCommand{})
+		return decode(envelope.Data, &command.GroupCommand{})
 	case IntervalType:
-		return decode(envelope.Data, &commands.IntervalCommand{})
+		return decode(envelope.Data, &command.IntervalCommand{})
 	case StatusType:
-		return &commands.StatusCommand{}, nil
+		return &command.StatusCommand{}, nil
 	default:
 		return nil, fmt.Errorf("unknown command type %q", envelope.Type)
 	}


### PR DESCRIPTION
The `internal/controller/commands` package is unnecessary and makes things
more complicated than they need to be.

Commands were moved into `internal/command`. Since this is an internal
package this is not a breaking change.